### PR TITLE
Add serialization for public keys

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 )
 
-var ErrorPointNotOnCurve error = errors.New("Point not on curve")
-var ErrorInvalidSignerState error = errors.New("Signer is in invalid state")
-var ErrorInvalidRequesterState error = errors.New("Signer is in invalid state")
-var ErrorInvalidSignature error = errors.New("Signature is invalid")
-var ErrorInvalidScalar error = errors.New("Scalar is too large")
+var (
+	ErrorPointNotOnCurve       = errors.New("Point not on curve")
+	ErrorInvalidSignerState    = errors.New("Signer is in invalid state")
+	ErrorInvalidRequesterState = errors.New("Signer is in invalid state")
+	ErrorInvalidSignature      = errors.New("Signature is invalid")
+	ErrorInvalidScalar         = errors.New("Scalar is too large")
+	ErrorInvalidPublicKey      = errors.New("Public key is invalid")
+)

--- a/keys.go
+++ b/keys.go
@@ -51,3 +51,20 @@ func (sk SecretKey) GetPublicKey() PublicKey {
 	pk.curve = sk.curve
 	return pk
 }
+
+func PublicKeyFromBytes(curve elliptic.Curve, val []byte) (PublicKey, error) {
+	x, y := elliptic.UnmarshalCompressed(curve, val)
+	if x == nil {
+		return PublicKey{}, ErrorInvalidPublicKey
+	}
+
+	return PublicKey{
+		curve: curve,
+		x:     x,
+		y:     y,
+	}, nil
+}
+
+func (pk PublicKey) Bytes() []byte {
+	return elliptic.MarshalCompressed(pk.curve, pk.x, pk.y)
+}


### PR DESCRIPTION
Here is a PR for the changes discussed in #2.

I'm not sure how you want to proceed with this, as I saw that you have exposed the public key fields in the [serial](https://github.com/rot256/pblind/tree/serial) branch already, but it's not merged yet.

We have internally reviewed these changes at https://github.com/safing/pblind/pull/1.

Resolves https://github.com/rot256/pblind/issues/2.